### PR TITLE
Use --no-quarantine flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Installation
 To install this cask simply execute 
 ```bash
-brew install --cask zirixcz/vesktop/vesktop
-```
-
-On MacOS you'll have to move Vesktop.app out of quarantine
-```bash
-xattr -d com.apple.quarantine /Applications/Vesktop.app
+brew install --cask zirixcz/vesktop/vesktop --no-quarantine
 ```


### PR DESCRIPTION
Homebrew already has a flag for disabling Gatekeeper, this PR adds it to the command to install. Might want to update the caveats too?